### PR TITLE
Workaround for issue with Safari that displays the same video 16 times.

### DIFF
--- a/app/components/channel-engine-video.component.js
+++ b/app/components/channel-engine-video.component.js
@@ -45,7 +45,12 @@ angular.module('channelEngineMultiview')
 
       self._initiatePlayer = function(hlsUri) {
         return new Promise(function(resolve, reject) {
-          if (self._canUseHls()) {
+          if (/Safari/.test(navigator.userAgent)) {
+            self.videoElement.src = hlsUri;
+            self.videoElement.addEventListener('canplay', function() {
+            });
+            resolve(self.videoElement);
+          } else if (self._canUseHls()) {
             var hls = self.hls;
             hls.attachMedia(self.videoElement);
             hls.on(Hls.Events.MEDIA_ATTACHED, function () {


### PR DESCRIPTION
We don't use Hls if the browser is Safari, we use the native hls support for Safari.