### PR TITLE
BUGFIX: was not working in Chrome because it used native video elemen…

### DIFF
--- a/app/components/channel-engine-video.component.js
+++ b/app/components/channel-engine-video.component.js
@@ -45,7 +45,7 @@ angular.module('channelEngineMultiview')
 
       self._initiatePlayer = function(hlsUri) {
         return new Promise(function(resolve, reject) {
-          if (/Safari/.test(navigator.userAgent)) {
+          if (self.videoElement.canPlayType('application/vnd.apple.mpegurl')) {
             self.videoElement.src = hlsUri;
             self.videoElement.addEventListener('canplay', function() {
             });
@@ -79,11 +79,6 @@ angular.module('channelEngineMultiview')
                 }
               }
             });
-          } else if (self.videoElement.canPlayType('application/vnd.apple.mpegurl')) {
-            self.videoElement.src = hlsUri;
-            self.videoElement.addEventListener('canplay', function() {
-            });
-            resolve(self.videoElement);
           } else {
             reject('Unsupported device');
           }


### PR DESCRIPTION
…t instead of HLS.js.

Using the navigator.userAgent is not robust enough, instead we first check if the browser can play m3u8 streams natively, and only if it cannot do we use HLS.js